### PR TITLE
chore: replace refs url with new prefix

### DIFF
--- a/draft-rfcxml-general-template-annotated-00.xml
+++ b/draft-rfcxml-general-template-annotated-00.xml
@@ -293,7 +293,7 @@ int main() {
       <references>
         <name>Normative References</name>
         
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8174.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
         <!-- The recommended and simplest way to include a well known reference -->
         
       </references>

--- a/draft-rfcxml-general-template-standard-00.xml
+++ b/draft-rfcxml-general-template-standard-00.xml
@@ -193,8 +193,8 @@ source code goes here [REPLACE]
       <references>
         <name>Normative References</name>
         
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2119.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8174.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
         <!-- The recommended and simplest way to include a well known reference -->
         
       </references>


### PR DESCRIPTION
new url prefix for refs should now be: https://bib.ietf.org/public/rfc/bibxml/
(from RFC editor instructions.